### PR TITLE
Added new MOS 1.04 API calls

### DIFF
--- a/include/mos_api.h
+++ b/include/mos_api.h
@@ -2,7 +2,7 @@
  * Title:			AGON MOS - MOS c header interface
  * Author:			Jeroen Venema
  * Created:			15/10/2022
- * Last Updated:	22/07/2023
+ * Last Updated:	18/11/2023
  * 
  * Modinfo:
  * 15/10/2022:		Added putch, getch
@@ -13,6 +13,7 @@
  * 19/04/2023:		Added mos_getfil
  * 02/07/2023:      Added struct / union for RTC_DATA
  * 22/07/2023:      Added structure for SYSVAR
+ * 18/11/2023:		Added mos_setkbvector, mos_getkbmap, mos_i2c_open, mos_i2c_close, mos_i2c_write, mos_i2c_read
  */
 
 #ifndef _MOS_H
@@ -233,4 +234,11 @@ extern uint24_t mos_fread(uint8_t fh, char *buffer, uint24_t numbytes);
 extern uint24_t mos_fwrite(uint8_t fh, char *buffer, uint24_t numbytes);
 extern uint8_t  mos_flseek(uint8_t fh, uint32_t offset);
 extern FIL*     mos_getfil(uint8_t fh);
+extern void     mos_setkbvector(void(*handler)(void), uint8_t addresslength);   // length 0:24bit, 1:16bit
+extern uint8_t* mos_getkbmap(void); // returns address of the keyboard map
+extern void     mos_i2c_open(uint8_t frequency);
+extern void     mos_i2c_close(void);
+extern uint8_t  mos_i2c_write(uint8_t i2c_address, uint8_t size, unsigned char * buffer);
+extern uint8_t  mos_i2c_read(uint8_t i2c_address, uint8_t size, unsigned char * buffer);
+
 #endif

--- a/include/mos_api.h
+++ b/include/mos_api.h
@@ -31,6 +31,17 @@ typedef uint8_t BYTE;
 #define FA_OPEN_ALWAYS		    0x10
 #define FA_OPEN_APPEND		    0x30
 
+// I2C frequency
+#define I2C_SPEED_57600			0x01
+#define I2C_SPEED_115200		0x02
+#define I2C_SPEED_230400		0x03
+// I2C return codes to caller
+#define RET_OK			        0x00
+#define RET_NORESPONSE	        0x01
+#define RET_DATA_NACK	        0x02
+#define RET_ARB_LOST	        0x04
+#define RET_BUS_ERROR	        0x08
+
 /* FatFS File function return code (FRESULT) */
 
 typedef enum {

--- a/lib/libc/mos_api.inc
+++ b/lib/libc/mos_api.inc
@@ -2,7 +2,7 @@
 ; Title:	AGON MOS - API for user projects
 ; Author:	Dean Belfield
 ; Created:	03/08/2022
-; Last Updated:	15/04/2023
+; Last Updated:	18/11/2023
 ; Adjusted for fasmg assembler (Paul Cawte, 16/06/2023)
 ;
 ; Modinfo:
@@ -21,6 +21,7 @@
 ; 29/03/2023:	Added mos_uopen, mos_uclose, mos_ugetc, mos_uputc
 ; 13/04/2023:	Added FatFS file structures (FFOBJID, FIL, DIR, FILINFO)
 ; 15/04/2023:	Added mos_getfil, mos_fread, mos_fwrite and mos_flseek
+; 18/11/2023:	Added _mos_setkbvector, _mos_getkbmap, _mos_i2c_open, _mos_i2c_close, _mos_i2c_write, _mos_i2c_read
 
 ; VDP control (VDU 23, 0, n)
 ;
@@ -67,6 +68,12 @@ mos_getfil		:=	019h
 mos_fread		:=	01Ah
 mos_fwrite		:=	01Bh
 mos_flseek		:=	01Ch
+mos_setkbvector	:=	01Dh
+mos_getkbmap	:=	01Eh
+mos_i2c_open	:=  01Fh
+mos_i2c_close	:=  020h
+mos_i2c_write	:=  021h
+mos_i2c_read	:=  022h
 
 ; FatFS file access functions
 ;

--- a/lib/libc/mos_api.src
+++ b/lib/libc/mos_api.src
@@ -2,7 +2,7 @@
 ; Title:		AGON MOS - MOS assembly interface
 ; Author:		Jeroen Venema updated by Paul Cawte for use with AgDev Toolchain
 ; Created:		15/10/2022
-; Last Updated:	02/07/2023
+; Last Updated:	18/11/2023
 ; 
 ; Modinfo:
 ; 02/07/2023		Added getsysvar_time
@@ -22,6 +22,7 @@
 ; 16/04/2023:		Added _mos_fread, _mos_fwrite and _mos_flseek
 ; 18/04/2023:		_mos_flseek fix
 ; 19/04/2023:		_mos_getfil added
+; 18/11/2023:		_mos_setkbvector, _mos_getkbmap, _mos_i2c_open, _mos_i2c_close, _mos_i2c_write, _mos_i2c_read added
 
 	assume	adl =1
 
@@ -61,6 +62,12 @@
 	public  _mos_fwrite
 	public  _mos_flseek
 	public  _mos_getfil
+	public  _mos_setkbvector
+	public  _mos_getkbmap
+	public  _mos_i2c_write
+	public  _mos_i2c_read
+	public  _mos_i2c_close
+	public  _mos_i2c_open
 
 	public	_getsysvar_time
 	public  _getsysvar_vpd_pflags
@@ -650,4 +657,71 @@ _mos_getfil:
 	rst.lil	08h				; Get a pointer to the relevant FIL struct
 	ld	sp, ix
 	pop	ix
+	ret
+
+_mos_setkbvector:
+	push	ix
+	ld 		ix,0
+	add 	ix, sp
+	ld	hl, (ix+6)
+	ld	c,	(ix+9)
+	ld a,	mos_setkbvector
+	rst.lil	08h
+	ld		sp,ix
+	pop		ix
+	ret
+
+_mos_getkbmap:
+	push	ix
+	ld a,	mos_getkbmap
+	rst.lil	08h
+	push	ix
+	pop		hl
+	pop		ix
+	ret
+
+_mos_i2c_open:
+	push	ix
+	ld 		ix,0
+	add 	ix, sp
+	ld	c, (ix+6)
+	ld a,	mos_i2c_open
+	rst.lil	08h
+	ld		sp,ix
+	pop		ix
+	ret
+
+_mos_i2c_close:
+	push	ix
+	ld 		ix,0
+	add 	ix, sp
+	ld a,	mos_i2c_close
+	rst.lil	08h
+	ld		sp,ix
+	pop		ix
+	ret
+_mos_i2c_write:
+	push	ix
+	ld 		ix,0
+	add 	ix, sp
+	ld		c, (ix+6)
+	ld		b, (ix+9)
+	ld		hl, (ix+12)
+	ld a,	mos_i2c_write
+	rst.lil	08h
+	ld		sp,ix
+	pop		ix
+	ret
+
+_mos_i2c_read:
+	push	ix
+	ld 		ix,0
+	add 	ix, sp
+	ld		c, (ix+6)
+	ld		b, (ix+9)
+	ld		hl, (ix+12)
+	ld a,	mos_i2c_read
+	rst.lil	08h
+	ld		sp,ix
+	pop		ix
 	ret


### PR DESCRIPTION
Added the following additional calls in the MOS 1.04 API:
- mos_setkbvector
- mos_getkbmap
- mos_i2c_open
- mos_i2c_close
- mos_i2c_write
- mos_i2c_read