### PR TITLE
Add an action to build a Windows ZIP

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
         run: |
           wget https://github.com/CE-Programming/toolchain/releases/download/v11.2/CEdev-Windows.zip
           mkdir /usr/share/CEdev
+          tar -xvf CEdev-Windows.zip -C /usr/share/
           rm CEdev-Windows.zip
           cp -r . /usr/share/CEdev/
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,3 +29,27 @@ jobs:
         with:
           file: /usr/share/AgDev_release_${{  github.ref_name }}.zip
           tags: true
+
+  release_windows:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Add CEdev-Windows
+        run: |
+          wget https://github.com/CE-Programming/toolchain/releases/download/v11.2/CEdev-Windows.zip
+          mkdir /usr/share/CEdev
+          rm CEdev-Windows.zip
+          cp -r . /usr/share/CEdev/
+
+      - name: Zip
+        run: |
+          cd /usr/share
+          zip -r AgDev_release_${{  github.ref_name }}.zip CEdev -x '*.git*' -x '*.github*'
+
+      - name: Upload to GitHub Release
+        uses: xresloader/upload-to-github-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          file: /usr/share/AgDev_release_${{  github.ref_name }}_Windows.zip
+          tags: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,17 +17,17 @@ jobs:
           rm CEdev-Linux.tar.gz
           cp -r . /usr/share/CEdev/
 
-      - name: Zip
+      - name: Zip (Linux)
         run: |
           cd /usr/share
-          zip -r AgDev_release_${{  github.ref_name }}.zip CEdev -x '*.git*' -x '*.github*'
+          zip -r AgDev_release_${{  github.ref_name }}_linux.zip CEdev -x '*.git*' -x '*.github*'
 
-      - name: Upload to GitHub Release
+      - name: Upload Linux ZIP to GitHub Release
         uses: xresloader/upload-to-github-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          file: /usr/share/AgDev_release_${{  github.ref_name }}.zip
+          file: /usr/share/AgDev_release_${{  github.ref_name }}_linux.zip
           tags: true
 
   release_windows:
@@ -41,15 +41,15 @@ jobs:
           rm CEdev-Windows.zip
           cp -r . /usr/share/CEdev/
 
-      - name: Zip
+      - name: Zip (Windows)
         run: |
           cd /usr/share
-          zip -r AgDev_release_${{  github.ref_name }}.zip CEdev -x '*.git*' -x '*.github*'
+          zip -r AgDev_release_${{  github.ref_name }}_windows.zip CEdev -x '*.git*' -x '*.github*'
 
-      - name: Upload to GitHub Release
+      - name: Upload Windows ZIP to GitHub Release
         uses: xresloader/upload-to-github-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          file: /usr/share/AgDev_release_${{  github.ref_name }}_Windows.zip
+          file: /usr/share/AgDev_release_${{  github.ref_name }}_windows.zip
           tags: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,8 @@ jobs:
         run: |
           wget https://github.com/CE-Programming/toolchain/releases/download/v11.2/CEdev-Windows.zip
           mkdir /usr/share/CEdev
+          unzip CEdev-Windows.zip -d /usr/share/
+          rm CEdev-Windows.zip
           cp -r . /usr/share/CEdev/
 
       - name: Zip (Windows)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,6 @@ jobs:
         run: |
           wget https://github.com/CE-Programming/toolchain/releases/download/v11.2/CEdev-Windows.zip
           mkdir /usr/share/CEdev
-          tar -xvf CEdev-Windows.zip -C /usr/share/
-          rm CEdev-Windows.zip
           cp -r . /usr/share/CEdev/
 
       - name: Zip (Windows)


### PR DESCRIPTION
Using the Linux version of CEDev as a basis produces a ZIP that's unusable on Windows - it's missing make.exe, for example.

I've added another GitHub action that produces a Windows version on each release. I'm sure it's possible to do a MacOS build the same way, but I haven't bothered.