### PR TITLE
Fix bug in return value of strcmp/strncmp

### DIFF
--- a/lib/libc/setjmp.src
+++ b/lib/libc/setjmp.src
@@ -34,8 +34,7 @@
 _setjmp:
 	ld 	iy,0
 	add 	iy,sp
-	push	iy		; replacing ld hl,iy ZDS pseudo op
-	pop 	hl
+	lea	hl,iy		; replacing ld hl,iy ZDS pseudo op
 	ld 	iy,(iy+3)	;get jmp_buf
 	ld 	(iy+3),ix	;save ix
 	ld 	(iy+6),hl	;save sp

--- a/lib/libc/strcmp.src
+++ b/lib/libc/strcmp.src
@@ -1,5 +1,7 @@
 ; (c) Copyright 2007-2008 Zilog, Inc.
 ;   int strcmp(register char *s1, register char *s2)
+; Changed to remove bug of typecasting difference value to signed char - should be difference of unsigned chars
+; Brendan Fletcher 19/03/2024
 
 	assume 	ADL=1
 
@@ -14,22 +16,19 @@ _strcmp:
 	inc	hl
 	ld	hl, (hl)
 
-_loop:
+.loop:
 	ld	a, (de)
 	or	a, a
-	jr	z, _done
+	jr	z, .done
 	cpi
 	inc	de
-	jr	z, _loop
+	jr	z, .loop
 
 	dec	hl
-_done:
+.done:
 	sub	a, (hl)
-
-	ld	b, a
-	rla
 	sbc	hl, hl
-	ld	l, b
+	ld	l, a
 	ret
 
 

--- a/lib/libc/strncmp.src
+++ b/lib/libc/strncmp.src
@@ -1,44 +1,39 @@
 ; (c) Copyright 2007-2008 Zilog, Inc.
 ;   int strncmp(char *s1,char *s2,size_t n)
+; Changed to remove bug of typecasting difference value to signed char - should be difference of unsigned chars
+; Brendan Fletcher 19/03/2024
 
 	ASSUME 	ADL=1
 
 	section	.text
 	public	_strncmp
 _strncmp:
-	ld		iy,	0
-	add		iy,	sp
+	ld	iy, 0
+	add	iy, sp
 
-	ld		bc, (iy+9)
-	ld		a,	(iy+11)
-	or		a,	c
-	or		a,	b
-	jr		z,	_done		; n==0 ? return(0)
+	ld	bc, (iy+9)
+	ld	a, (iy+11)
+	or	a, c
+	or	a, b
+	jr	z, .done	; n==0 ? return(0)
 
-	ld		hl,	(iy+6)
-	ld		de,	(iy+3)
+	ld	hl, (iy+6)
+	ld	de, (iy+3)
 
-_cloop:
-	ld		a,	(de)
+.cloop:
+	ld	a, (de)
+	or	a, a
+	jr	z, .diffnul	; return the difference value if *s1=='\0'
 	cpi
-	jr		nz,	_diff		; return the difference value if mismatch occurs
-	jp		po, _done		; if all the chars over then return(0)
-	or		a,	a
-	jr		z,	_done		; if *s1=='\0'	return(0)
-	inc		de
-	jr		_cloop
+	jr	nz, .diff	; return the difference value if mismatch occurs
+	inc	de
+	jp	pe, .cloop	; if all the chars not over then loop
 
-_diff:
-	dec		hl
-	sub		a, (hl)
-	ld		b,	a
-	rla
-	sbc		hl,	hl
-	ld		l,	b
+.diff:
+	dec	hl
+.diffnul:
+	sub	a, (hl)
+.done:
+	sbc	hl, hl
+	ld	l, a
 	ret
-
-_done:
-	or		a,	a
-	sbc		hl,	hl
-	ret
-

--- a/lib/libc/strstr.src
+++ b/lib/libc/strstr.src
@@ -10,7 +10,7 @@
 	public	_strstr
 _strstr:
 	ld 	hl, 6
-	add hl, sp
+	add	hl, sp
 	ld	iy, (hl)	; bc = s2
 	dec 	hl
 	dec 	hl
@@ -22,21 +22,20 @@ _L0:
 	add	hl,de
 	cp	a,(hl)
 	jr	z,_L3		; *s1 == '\0'
-	push	iy		; replace ZDS pseudo op ld bc,iy
-	pop	bc
+	lea	bc,iy		; replace ZDS pseudo op ld bc,iy
 	inc	de
 _L1:
 	ld	a,(bc)
 	or	a,a
 	jr	z,_L2		; *s2 == '\0'
 	cp	a,(hl)		; *s1 == *s2
-	inc hl			; s1 ++
-	inc bc			; s2 ++
+	inc	hl		; s1 ++
+	inc	bc		; s2 ++
 	jr	z,_L1
 	jr	_L0
 _L2:
 	ex	de,hl
-	dec hl
+	dec	hl
 	ret
 _L3:
 	sbc	hl,hl


### PR DESCRIPTION
Zilog's implementations of `strcmp` and `strncmp` oddly sign extend the difference of the two characters. This notably has the following problems:

- The C standard specifies the characters should be compared as `unsigned char`. Zilog's behavior is fine if all characters are in the ASCII range and thus differ by no more than 127, but larger differences may be returned with the wrong sign.
- This behavior causes strings not to have a total ordering - for example, 0x20 < 0x70 and 0x70 < 0xC0 but 0x20 > 0xC0.
- This was fixed by TI in their OS implementation, so this causes behavior different than in CEdev programs.

I was able to fix this (which ends up with better performance in the difference calculation so it's a win-win), and while I was at it, I also optimized the `strncmp` loop a bit. I also improved a couple of the pseudo op replacements from earlier Zilog routine edits.

I should also note that on the CEdev side, I fixed the `strncasecmp` errors which had been reported earlier, and also added an implementation for `strcasecmp`, so that should be usable in AgDev.